### PR TITLE
Add support for outbound SMTP and inbound GitHub Actions

### DIFF
--- a/virtual_network/nsg.tf
+++ b/virtual_network/nsg.tf
@@ -178,3 +178,20 @@ resource "azurerm_network_security_rule" "outbound-http-to-internet" {
   destination_address_prefix  = "Internet"
   destination_port_ranges     = ["80","443"]
 }
+
+# Allow outbound SMTP to the Internet
+resource "azurerm_network_security_rule" "outbound-smtp-to-internet" {
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = azurerm_network_security_group.main.name
+
+  name = "outbound-smtp-to-internet"
+
+  priority                    = 510
+  direction                   = "Outbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_address_prefix       = "VirtualNetwork"
+  source_port_range           = "*"
+  destination_address_prefix  = "Internet"
+  destination_port_range      = "587"
+}

--- a/vm/networking.tf
+++ b/vm/networking.tf
@@ -136,3 +136,83 @@ resource "azurerm_network_security_rule" "inbound-github-hooks" {
   destination_application_security_group_ids  = [azurerm_application_security_group.main.id]
   destination_port_range                      = "443"
 }
+
+resource "azurerm_network_security_rule" "inbound-github-actions-eastus" {
+  name  = "inbound-github-actions-eastus"
+
+  resource_group_name = var.resource_group_name
+  network_security_group_name = var.tfe_subnet_nsg
+
+  priority                                    = 520
+  direction                                   = "Inbound"
+  access                                      = "Allow"
+  protocol                                    = "Tcp"
+  source_address_prefix                       = "AzureCloud.eastus"
+  source_port_range                           = "*"
+  destination_application_security_group_ids  = [azurerm_application_security_group.main.id]
+  destination_port_range                      = "443"
+}
+
+resource "azurerm_network_security_rule" "inbound-github-actions-eastus2" {
+  name  = "inbound-github-actions-eastus2"
+
+  resource_group_name = var.resource_group_name
+  network_security_group_name = var.tfe_subnet_nsg
+
+  priority                                    = 521
+  direction                                   = "Inbound"
+  access                                      = "Allow"
+  protocol                                    = "Tcp"
+  source_address_prefix                       = "AzureCloud.eastus2"
+  source_port_range                           = "*"
+  destination_application_security_group_ids  = [azurerm_application_security_group.main.id]
+  destination_port_range                      = "443"
+}
+
+resource "azurerm_network_security_rule" "inbound-github-actions-westus2" {
+  name  = "inbound-github-actions-westus2"
+
+  resource_group_name = var.resource_group_name
+  network_security_group_name = var.tfe_subnet_nsg
+
+  priority                                    = 522
+  direction                                   = "Inbound"
+  access                                      = "Allow"
+  protocol                                    = "Tcp"
+  source_address_prefix                       = "AzureCloud.westus2"
+  source_port_range                           = "*"
+  destination_application_security_group_ids  = [azurerm_application_security_group.main.id]
+  destination_port_range                      = "443"
+}
+
+resource "azurerm_network_security_rule" "inbound-github-actions-centralus" {
+  name  = "inbound-github-actions-centralus"
+
+  resource_group_name = var.resource_group_name
+  network_security_group_name = var.tfe_subnet_nsg
+
+  priority                                    = 523
+  direction                                   = "Inbound"
+  access                                      = "Allow"
+  protocol                                    = "Tcp"
+  source_address_prefix                       = "AzureCloud.centralus"
+  source_port_range                           = "*"
+  destination_application_security_group_ids  = [azurerm_application_security_group.main.id]
+  destination_port_range                      = "443"
+}
+
+resource "azurerm_network_security_rule" "inbound-github-actions-southcentralus" {
+  name  = "inbound-github-actions-southcentralus"
+
+  resource_group_name = var.resource_group_name
+  network_security_group_name = var.tfe_subnet_nsg
+
+  priority                                    = 524
+  direction                                   = "Inbound"
+  access                                      = "Allow"
+  protocol                                    = "Tcp"
+  source_address_prefix                       = "AzureCloud.southcentralus"
+  source_port_range                           = "*"
+  destination_application_security_group_ids  = [azurerm_application_security_group.main.id]
+  destination_port_range                      = "443"
+}


### PR DESCRIPTION
This adds the following capabilities:
- When setting up TFE to send email, port 587 outbound is required.
- As we use GitHub Actions for some automation pieces, we need to allow US Azure datacenters, as noted in the GitHub Actions docs [here](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#ip-addresses-of-runners-on-github-hosted-machines).