### PR TITLE
Add an empty subnet for a future, optional instance of Hashicorp Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ So while this code may not be as reusable as your typical Terraform module, its 
 The code in this repository creates a number of things:
 
 1. An Azure Resource Group to contain all the other resources.
-1. An Azure Virtual Network with one subnet.
-1. An Azure Key Vault. This will only store a few small things: the storage account keys, the Postgres database user and password, and the SSL cert for TFE and associated private key. This is NOT used by TFE directly.
+1. An Azure Virtual Network with two subnets, one for TFE, one for an optional instance of HashiCorp Vault. The latter will remain empty and unused unless you use the Terraform code to "append" this instance of Vault to your TFE implementation. The code is available in a separate repository, and includes separate documentation.
+1. An Azure Key Vault. This will only store a few small things: the storage account keys, the Postgres database user and password, and a few other secrets. This is NOT used by TFE directly, only to bring up TFE and its database.
 1. An Azure Storage Account with a Blob container and a Files endpoint. The Blob container will hold the TFE license file as well as some of the TFE application data. The Files endpoint is a CIFS share that is mounted to the VM. TFE will store its application snapshots there.
 1. A PostgreSQL database instance. By default, only TFE will be able to connect to the DB. You can configure the database firewall to allow connections from your workstation if needed. This should be avoided except for troubleshooting, and is done outside of this module (an example is provided farther down).
 1. An Azure VM for the TFE application. This VM is assigned a managed identity allowing it to download required secrets from Key Vault.

--- a/key_vault/main.tf
+++ b/key_vault/main.tf
@@ -13,7 +13,7 @@ resource "azurerm_key_vault" "main" {
     default_action              = "Deny"
     bypass                      = "AzureServices"
     ip_rules                    = local.ip_whitelist
-    virtual_network_subnet_ids  = list(var.tfe_subnet)
+    virtual_network_subnet_ids  = list(var.tfe_subnet, var.vault_subnet)
   }
 
   tags = var.tags

--- a/key_vault/vars.tf
+++ b/key_vault/vars.tf
@@ -21,6 +21,11 @@ variable "tfe_subnet" {
   description = "The ID of the subnet where the TFE instance lives."
 }
 
+variable "vault_subnet" {
+  type = string
+  description = "The ID of the subnet where the Vault instance lives."
+}
+
 variable "name_randomness" {
   type = number
   description = "An arbitrary number that is used to 'randomize' the hostname of the Key Vault, you need to set this to any number between 0 and 255"

--- a/virtual_network/outputs.tf
+++ b/virtual_network/outputs.tf
@@ -14,6 +14,14 @@ output "subnet_id" {
   value = azurerm_subnet.main.id
 }
 
+output "vault_subnet_name" {
+  value = azurerm_subnet.vault.name
+}
+
+output "vault_subnet_id" {
+  value = azurerm_subnet.vault.id
+}
+
 output "subnet_nsg_name" {
   value = azurerm_network_security_group.main.name
 }

--- a/virtual_network/vnet.tf
+++ b/virtual_network/vnet.tf
@@ -24,3 +24,20 @@ resource "azurerm_subnet" "main" {
     "Microsoft.Storage",
   ]
 }
+
+resource "azurerm_subnet" "vault" {
+  name                 = "tfe-vault-${var.names.environment}-${var.names.location}-subnet"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.main.name
+
+  address_prefixes     = [cidrsubnet(azurerm_virtual_network.main.address_space[0], 1, 1)]
+
+  enforce_private_link_endpoint_network_policies = true
+  enforce_private_link_service_network_policies  = false
+
+  service_endpoints = [
+    "Microsoft.KeyVault",
+    "Microsoft.Sql",
+    "Microsoft.Storage",
+  ]
+}


### PR DESCRIPTION
As the title says, this adds an empty subnet to the Azure Virtual Network, with a view to install a private instance of Hashicorp Vault in that subnet.

Originally, I was working on implementing this subnet through the separate Vault module I'm writing, but this Vault instance would require access to the Azure Key Vault provided by this module, and it proved impossible to grant the subnet access to the Key Vault instance when I managed said subnet outside of this module.

So I added the empty subnet to this module. TFE will not use this subnet at all but this allows managing the Key Vault network ACL to allow the extra subnet to connect to Key Vault as well.

Further management of this subnet happens in the separate Vault module I'm working on (not published yet).

To summarize again, this PR adds an empty subnet, ensures this subnet has connectivity to Key Vault, and adds outputs to the virtual network submodule allowing the Vault module to integrate with this.